### PR TITLE
tests: Disable checkov report upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,13 +36,14 @@ jobs:
           # This will add both a CLI output to the console and create a results.sarif file
           output_format: cli,sarif
           output_file_path: console,results.sarif
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+      # Upload can be enabled as soon the repository is public
+      #- name: Upload SARIF file
+      #  uses: github/codeql-action/upload-sarif@v3
         # Results are generated only on a success or failure
         # this is required since GitHub by default won't run the next step
         # when the previous one has failed. Security checks that do not pass will 'fail'.
         # An alternative is to add `continue-on-error: true` to the previous step
         # Or 'soft_fail: true' to checkov.
-        if: success() || failure()
-        with:
-          sarif_file: results.sarif
+      #  if: success() || failure()
+      #  with:
+      #    sarif_file: results.sarif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://github.com/aws-samples/suse-linux-on-aws-workshop/actions/runs/8664165465 failed, this is because the repo is private right now. Disabling checkov report upload till the repo becomes public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
